### PR TITLE
Add payment management API and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2979,7 +2979,10 @@ name = "manager"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode 2.0.1",
  "fedimint-core",
+ "fedimint-lnv2-common",
+ "futures-lite",
  "iroh",
  "iroh-blobs",
  "iroh-docs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ shared = { path = "./shared" }
 tempfile = "3.20.0"
 tokio = { version = "1.45.0", features = ["macros", "rt"] }
 uuid = { version = "1.16.0", features = ["v4"] }
+futures-lite = "2.0.1"

--- a/manager/Cargo.toml
+++ b/manager/Cargo.toml
@@ -16,4 +16,7 @@ serde_json = { workspace = true }
 shared = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }
+fedimint-lnv2-common = { workspace = true }
+bincode = { workspace = true }
+futures-lite = "2"
 


### PR DESCRIPTION
## Summary
- implement `list_claimable_payments_for_machine` and `remove_claimed_payment`
- expose blobs in `ManagerProtocol`
- add futures-lite and bincode deps
- implement integration tests covering payment flows

## Testing
- `cargo test`