### PR TITLE
chore: downgrade cloud runner from a 16 core to an 8 core machine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           mode: create
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
-          server_type: cx52
+          server_type: cx42
 
   build:
     needs: create-runner


### PR DESCRIPTION
I'm running into Hetzner resource limitations when trying to spin up 16-core CX52 VMs, so let's try downgrading